### PR TITLE
Expose client queries and mutations

### DIFF
--- a/examples/apollo-client/test/mutations.spec.ts
+++ b/examples/apollo-client/test/mutations.spec.ts
@@ -19,24 +19,6 @@ describe("test mutations", () => {
     }
   `;
 
-  const UPDATE_ITEM = gql`
-    mutation updateItem($id: ID!, $title: String!) {
-      updateItem(id: $id, input: { title: $title }) {
-        id
-        title
-      }
-    }
-  `;
-
-  const FIND_ALL_ITEMS = gql`
-    query findAllItems {
-      findAllItems {
-        id
-        title
-      }
-    }
-  `;
-
   before("start graphql server", async () => {
     const schema = readFileSync(resolve(__dirname, '../fixtures/schema.graphql'), 'utf8');
     server = new TestxServer(schema);
@@ -66,13 +48,13 @@ describe("test mutations", () => {
 
   it("should update existing item", async () => {
     const findResult = await client.query({
-      query: FIND_ALL_ITEMS
+      query: gql`${server.getQueries().findAllItems}`
     });
     const itemV1 = findResult.data.findAllItems.find(i => i.title === "TestA");
     expect(itemV1).to.be.exist;
 
     const updateResult = await client.mutate({
-      mutation: UPDATE_ITEM,
+      mutation: gql`${server.getMutations().updateItem}`,
       variables: { id: itemV1.id, title: "TestB" }
     });
     const itemV2 = updateResult.data.updateItem;

--- a/examples/offix/test/offline.test.ts
+++ b/examples/offix/test/offline.test.ts
@@ -46,18 +46,6 @@ async function newClient(
 // TODO: remove this queries once we expose client queries/mutations
 // TODO: from the TestxServer API
 // TODO: https://github.com/aerogear/graphql-testx/issues/15
-export const FIND_ALL_TASKS = gql`
-  query findAllTasks {
-    findAllTasks {
-      id
-      version
-      title
-      description
-      author
-    }
-  }
-`;
-
 export const ADD_TASK = gql`
   mutation createTask(
     $version: Int!
@@ -66,32 +54,6 @@ export const ADD_TASK = gql`
     $author: String!
   ) {
     createTask(
-      input: {
-        version: $version
-        title: $title
-        description: $description
-        author: $author
-      }
-    ) {
-      id
-      version
-      title
-      description
-      author
-    }
-  }
-`;
-
-export const UPDATE_TASK = gql`
-  mutation updateTask(
-    $id: ID!
-    $version: Int!
-    $title: String!
-    $description: String!
-    $author: String!
-  ) {
-    updateTask(
-      id: $id
       input: {
         version: $version
         title: $title
@@ -152,7 +114,7 @@ it("update an object while offline and assert that the object get updated on the
   // update the task while offline
   try {
     await client.offlineMutation({
-      mutation: UPDATE_TASK,
+      mutation: gql`${server.getMutations().updateTask}`,
       variables: {
         ...newTask,
         title: "something new",
@@ -172,7 +134,7 @@ it("update an object while offline and assert that the object get updated on the
 
   // query all tasks ignoring the cache
   const findAllTasksResult = await client.query({
-    query: FIND_ALL_TASKS,
+    query: gql`${server.getQueries().findAllTasks}`,
     fetchPolicy: "network-only"
   });
 

--- a/src/BackendBuilder.ts
+++ b/src/BackendBuilder.ts
@@ -50,7 +50,7 @@ export class BackendBuilder {
   private generateResolvers() {
     const modules: { [id: string]: any } = {};
 
-    this.backend.resolvers.types.map((item) => {
+    this.backend.resolvers.types.forEach((item) => {
       modules[`./generated/${item.name}`] = sourceModule(
         transpile(item.output),
       );
@@ -82,14 +82,14 @@ export class BackendBuilder {
 
     const modules: { [id: string]: any } = {};
 
-    fragments.map((item) => {
+    fragments.forEach((item) => {
       modules[`../fragments/${item.name}`] = sourceModule(
         transpile(item.implementation),
       );
     });
 
     const clientQueries = {};
-    queries.map((item) => {
+    queries.forEach((item) => {
       clientQueries[item.name] = print(sourceModule(
         transpile(item.implementation),
         modules,
@@ -97,7 +97,7 @@ export class BackendBuilder {
     });
 
     const clientMutations = {};
-    mutations.map((item) => {
+    mutations.forEach((item) => {
       clientMutations[item.name] = print(sourceModule(
         transpile(item.implementation),
         modules,

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -9,15 +9,6 @@ const ITEM_MODEL = `
   }
 `;
 
-const FIND_ALL_ITEMS = `
-  query findAllItems {
-    findAllItems {
-      id
-      title
-    }
-  }
-`;
-
 const CREATE_ITEM = `
   mutation {
     createItem( input: { title: "test" } ) {
@@ -56,15 +47,15 @@ test.serial("stop() method should preserve stored items", async t => {
   const serverUrl = server.url()
 
   await request(serverUrl, CREATE_ITEM);
-  let result = await request(serverUrl, FIND_ALL_ITEMS);
+  let result = await request(serverUrl, server.getQueries().findAllItems);
   t.assert(result.findAllItems.length === 1, "Created item should be successfully fetched")
 
   server.stop()
 
-  await t.throwsAsync(async() => { await request(serverUrl, FIND_ALL_ITEMS) }, null, "Should throw an error after stopping the server (ECONNREFUSED)")
+  await t.throwsAsync(async() => { await request(serverUrl, server.getQueries().findAllItems) }, null, "Should throw an error after stopping the server (ECONNREFUSED)")
   
   await server.start()
-  result = await request(serverUrl, FIND_ALL_ITEMS);
+  result = await request(serverUrl, server.getQueries().findAllItems);
   t.assert(result.findAllItems.length === 1, "The item should be still present after resuming the server")
 })
 
@@ -75,11 +66,11 @@ test.serial("cleanDatabase() method should remove all items", async t => {
   const serverUrl = server.url()
 
   await request(serverUrl, CREATE_ITEM);
-  let result = await request(serverUrl, FIND_ALL_ITEMS);
+  let result = await request(serverUrl, server.getQueries().findAllItems);
   t.assert(result.findAllItems.length === 1, "Created item should be successfully fetched")
 
   await server.cleanDatabase()
 
-  result = await request(serverUrl, FIND_ALL_ITEMS);
+  result = await request(serverUrl, server.getQueries().findAllItems);
   t.assert(result.findAllItems.length === 0, "The item should be gone after calling cleanDatabase() method")
 })

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -28,13 +28,12 @@ const CREATE_ITEM = `
 `;
 
 test.serial("start TestxServer server", async t => {
-
   const server = new TestxServer(ITEM_MODEL);
 
   await server.start();
   t.assert(server.url());
 
-  const result = await request(server.url(), FIND_ALL_ITEMS);
+  const result = await request(server.url(), server.getQueries().findAllItems);
   t.assert(result.findAllItems.length === 0);
 });
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.
-->

### Description

This PR adds the featuring of exposing client queries and mutations to the user.
The queries and mutations can be obtained using `TestxServer.getQueries()` and `TestxServer.getMutations()`.

**Example**:

```javascript
const server = new TestxServer(`
  type Item {
    id: ID!
    name: String
    title: String!
  }`);

await server.start();

const FIND_ALL_ITEMS = gql`${server.getQueries().findAllItems}`
const UPDATE_ITEM = gql`${server.getMutations().updateItem}`
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] `npm run build` works
- [x] tests are included
- [ ] documentation is changed or added