### PR TITLE
Expose client subscriptions

### DIFF
--- a/examples/apollo-client/package.json
+++ b/examples/apollo-client/package.json
@@ -7,8 +7,10 @@
     "@types/chai": "4.2.5",
     "@types/mocha": "5.2.7",
     "apollo-boost": "0.4.4",
+    "apollo-link-ws": "1.0.19",
     "chai": "4.2.0",
     "mocha": "6.2.0",
-    "node-fetch": "2.6.0"
+    "node-fetch": "2.6.0",
+    "subscriptions-transport-ws": "0.9.16"
   }
 }

--- a/examples/apollo-client/test/subscriptions.spec.ts
+++ b/examples/apollo-client/test/subscriptions.spec.ts
@@ -17,7 +17,6 @@ import { StringDic } from "../../../src/TestxApi";
 describe("test subscriptions", () => {
   let server: TestxServer;
   let client: ApolloClient<unknown>;
-  let queries: StringDic;
   let mutations: StringDic;
   let subscriptions: StringDic;
   let wsLink: WebSocketLink;
@@ -32,7 +31,6 @@ describe("test subscriptions", () => {
     await server.start();
     console.log(`Running on ${await server.httpUrl()}`);
 
-    queries = await server.getQueries()
     mutations = await server.getMutations();
     subscriptions = await server.getSubscriptions();
   });
@@ -79,7 +77,7 @@ describe("test subscriptions", () => {
       {query: gql(subscriptions.newItem), variables: {}}
     );
 
-    let subResult = makePromise(query);
+    const subResult = makePromise(query);
 
     const item = (await client.mutate({
       mutation: gql(mutations.createItem),
@@ -95,7 +93,7 @@ describe("test subscriptions", () => {
       {query: gql(subscriptions.updatedItem), variables: {}}
     );
 
-    let subResult = makePromise(query);
+    const subResult = makePromise(query);
 
     const itemV2 = (await client.mutate({
       mutation: gql(mutations.updateItem),

--- a/examples/apollo-client/test/subscriptions.spec.ts
+++ b/examples/apollo-client/test/subscriptions.spec.ts
@@ -45,7 +45,7 @@ describe("test subscriptions", () => {
 
   before("initialize apollo client", async () => {
     const httpUrl = await server.httpUrl();
-    const wsUrl = httpUrl.replace('http', 'ws');
+    const wsUrl = await server.subscriptionsUrl();
 
     clientSub = new SubscriptionClient(
       wsUrl, {reconnect: true}, WebSocket

--- a/examples/apollo-client/test/subscriptions.spec.ts
+++ b/examples/apollo-client/test/subscriptions.spec.ts
@@ -79,17 +79,14 @@ describe("test subscriptions", () => {
       {query: gql(subscriptions.newItem), variables: {}}
     );
 
-    let subResult;
-    makePromise(query).then(data => {
-      subResult = data.data.newItem;
-    });
+    let subResult = makePromise(query);
 
     const item = (await client.mutate({
       mutation: gql(mutations.createItem),
       variables: { title: "TestA" }
     })).data.createItem;
 
-    expect(item.title).to.be.equal(subResult.title);
+    expect(item.title).to.be.equal((await subResult).data.newItem.title);
   });
 
   it("should updatedItem subscription", async () => {
@@ -98,16 +95,13 @@ describe("test subscriptions", () => {
       {query: gql(subscriptions.updatedItem), variables: {}}
     );
 
-    let subResult;
-    makePromise(query).then(data => {
-      subResult = data.data.updatedItem;
-    });
+    let subResult = makePromise(query);
 
     const itemV2 = (await client.mutate({
       mutation: gql(mutations.updateItem),
       variables: { id: 1, title: "TestB" }
     })).data.updateItem;
 
-    expect(itemV2.title).to.be.equal(subResult.title);
+    expect(itemV2.title).to.be.equal((await subResult).data.updatedItem.title);
   });
 });

--- a/examples/apollo-client/test/subscriptions.spec.ts
+++ b/examples/apollo-client/test/subscriptions.spec.ts
@@ -43,7 +43,7 @@ describe("test subscriptions", () => {
 
   before("initialize apollo client", async () => {
     const httpUrl = await server.httpUrl();
-    const wsUrl = await server.subscriptionsUrl();
+    const wsUrl = await server.wsUrl();
 
     clientSub = new SubscriptionClient(
       wsUrl, {reconnect: true}, WebSocket

--- a/examples/apollo-client/test/subscriptions.spec.ts
+++ b/examples/apollo-client/test/subscriptions.spec.ts
@@ -1,0 +1,113 @@
+import { expect } from "chai";
+import gql from "graphql-tag";
+import fetch from "node-fetch";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+import { TestxServer } from "../../../src";
+import { execute, makePromise, split } from 'apollo-link';
+import { WebSocketLink } from 'apollo-link-ws';
+import { SubscriptionClient } from 'subscriptions-transport-ws';
+import WebSocket from 'ws';
+import { getMainDefinition } from 'apollo-utilities';
+import { ApolloClient } from 'apollo-client'
+import { InMemoryCache } from 'apollo-cache-inmemory';
+import { createHttpLink } from 'apollo-link-http';
+import { StringDic } from "../../../src/TestxApi";
+
+describe("test subscriptions", () => {
+  let server: TestxServer;
+  let client: ApolloClient<unknown>;
+  let queries: StringDic;
+  let mutations: StringDic;
+  let subscriptions: StringDic;
+  let wsLink: WebSocketLink;
+  let clientSub: SubscriptionClient;
+
+  before("start graphql server", async () => {
+    const schema = readFileSync(
+      resolve(__dirname, "../fixtures/mutations-schema.graphql"),
+      "utf8"
+    );
+    server = new TestxServer(schema);
+    await server.start();
+    console.log(`Running on ${await server.httpUrl()}`);
+
+    queries = await server.getQueries()
+    mutations = await server.getMutations();
+    subscriptions = await server.getSubscriptions();
+  });
+
+  after("close graphql server", () => {
+    server.close();
+    clientSub.close();
+    console.log(`Connection with server closed`);
+  });
+
+  before("initialize apollo client", async () => {
+    const httpUrl = await server.httpUrl();
+    const wsUrl = httpUrl.replace('http', 'ws');
+
+    clientSub = new SubscriptionClient(
+      wsUrl, {reconnect: true}, WebSocket
+    );
+
+    wsLink = new WebSocketLink(clientSub);
+    const httpLink = createHttpLink({
+      uri: httpUrl,
+      fetch: fetch
+    });
+
+    const link = split(
+      ({ query }) => {
+        const definition = getMainDefinition(query);
+        return definition.kind === 'OperationDefinition' && definition.operation === 'subscription';
+      },
+      wsLink,
+      httpLink
+    );
+
+    const cache = new InMemoryCache();
+    client = new ApolloClient({
+      link,
+      cache
+    });
+  });
+
+  it("test newItem subscription", async () => {
+    const query = execute(
+      wsLink,
+      {query: gql(subscriptions.newItem), variables: {}}
+    );
+
+    let subResult;
+    makePromise(query).then(data => {
+      subResult = data.data.newItem;
+    });
+
+    const item = (await client.mutate({
+      mutation: gql(mutations.createItem),
+      variables: { title: "TestA" }
+    })).data.createItem;
+
+    expect(item.title).to.be.equal(subResult.title);
+  });
+
+  it("should updatedItem subscription", async () => {
+    const query = execute(
+      wsLink,
+      {query: gql(subscriptions.updatedItem), variables: {}}
+    );
+
+    let subResult;
+    makePromise(query).then(data => {
+      subResult = data.data.updatedItem;
+    });
+
+    const itemV2 = (await client.mutate({
+      mutation: gql(mutations.updateItem),
+      variables: { id: 1, title: "TestB" }
+    })).data.updateItem;
+
+    expect(itemV2.title).to.be.equal(subResult.title);
+  });
+});

--- a/examples/apollo-client/yarn.lock
+++ b/examples/apollo-client/yarn.lock
@@ -139,6 +139,14 @@ apollo-link-http@^1.3.1:
     apollo-link-http-common "^0.2.15"
     tslib "^1.9.3"
 
+apollo-link-ws@1.0.19:
+  version "1.0.19"
+  resolved "https://registry.yarnpkg.com/apollo-link-ws/-/apollo-link-ws-1.0.19.tgz#dfa871d4df883a8777c9556c872fc892e103daa5"
+  integrity sha512-mRXmeUkc55ixOdYRtfq5rq3o9sboKghKABKroDVhJnkdS56zthBEWMAD+phajujOUbqByxjok0te8ABqByBdeQ==
+  dependencies:
+    apollo-link "^1.2.13"
+    tslib "^1.9.3"
+
 apollo-link@^1.0.0, apollo-link@^1.0.6, apollo-link@^1.2.13:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/apollo-link/-/apollo-link-1.2.13.tgz#dff00fbf19dfcd90fddbc14b6a3f9a771acac6c4"
@@ -170,6 +178,16 @@ assertion-error@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
   integrity sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==
+
+async-limiter@~1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"
+  integrity sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==
+
+backo2@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/backo2/-/backo2-1.0.2.tgz#31ab1ac8b129363463e35b3ebb69f4dfcfba7947"
+  integrity sha1-MasayLEpNjRj41s+u2n038+6eUc=
 
 balanced-match@^1.0.0:
   version "1.0.0"
@@ -339,6 +357,11 @@ esprima@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
+
+eventemitter3@^3.1.0:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.2.tgz#2d3d48f9c346698fce83a85d7d664e98535df6e7"
+  integrity sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==
 
 execa@^1.0.0:
   version "1.0.0"
@@ -516,6 +539,11 @@ isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
+
+iterall@^1.2.1:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.2.2.tgz#92d70deb8028e0c39ff3164fdbf4d8b088130cd7"
+  integrity sha512-yynBb1g+RFUPY64fTrFv7nsjRrENBQJaX2UL+2Szc9REFrSNm1rpSXHGzhmAy7a9uv3vlvgBlXnf9RqmPH1/DA==
 
 js-yaml@3.13.1:
   version "3.13.1"
@@ -894,6 +922,17 @@ strip-json-comments@2.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
 
+subscriptions-transport-ws@0.9.16:
+  version "0.9.16"
+  resolved "https://registry.yarnpkg.com/subscriptions-transport-ws/-/subscriptions-transport-ws-0.9.16.tgz#90a422f0771d9c32069294c08608af2d47f596ec"
+  integrity sha512-pQdoU7nC+EpStXnCfh/+ho0zE0Z+ma+i7xvj7bkXKb1dvYHSZxgRPaU6spRP+Bjzow67c/rRDoix5RT0uU9omw==
+  dependencies:
+    backo2 "^1.0.2"
+    eventemitter3 "^3.1.0"
+    iterall "^1.2.1"
+    symbol-observable "^1.0.4"
+    ws "^5.2.0"
+
 supports-color@6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-6.0.0.tgz#76cfe742cf1f41bb9b1c29ad03068c05b4c0e40a"
@@ -908,7 +947,7 @@ supports-color@^5.3.0:
   dependencies:
     has-flag "^3.0.0"
 
-symbol-observable@^1.0.2:
+symbol-observable@^1.0.2, symbol-observable@^1.0.4:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
   integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
@@ -961,6 +1000,13 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
+
+ws@^5.2.0:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-5.2.2.tgz#dffef14866b8e8dc9133582514d1befaf96e980f"
+  integrity sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==
+  dependencies:
+    async-limiter "~1.0.0"
 
 "y18n@^3.2.1 || ^4.0.0", y18n@^4.0.0:
   version "4.0.0"

--- a/src/GraphbackClient.ts
+++ b/src/GraphbackClient.ts
@@ -20,11 +20,13 @@ export class GraphbackClient {
   private queries: StringDic;
   private mutations: StringDic;
   private fragments: StringDic;
+  private subscriptions: StringDic;
 
-  constructor(queries: StringDic, mutations: StringDic, fragments: StringDic) {
+  constructor(queries: StringDic, mutations: StringDic, fragments: StringDic, subscriptions: StringDic) {
     this.queries = queries;
     this.mutations = mutations;
     this.fragments = fragments;
+    this.subscriptions = subscriptions;
   }
 
   public getQueries(): StringDic {
@@ -38,6 +40,10 @@ export class GraphbackClient {
   public getFragments(): StringDic {
     return this.fragments;
   }
+
+  public getSubscriptions(): StringDic {
+    return this.subscriptions;
+  }
 }
 
 export async function initGraphbackClient(
@@ -49,6 +55,7 @@ export async function initGraphbackClient(
   const fragments: StringDic = {};
   const queries: StringDic = {};
   const mutations: StringDic = {};
+  const subscriptions: StringDic = {};
 
   if (client.fragments !== undefined) {
     client.fragments.forEach(item => {
@@ -72,5 +79,12 @@ export async function initGraphbackClient(
     });
   }
 
-  return new GraphbackClient(queries, mutations, fragments);
+  if (client.subscriptions !== undefined) {
+    client.subscriptions.forEach(item => {
+      const m = sourceModule(transpile(item.implementation), modules);
+      subscriptions[item.name] = print((m as ASTNodeDic)[item.name]);
+    });
+  }
+
+  return new GraphbackClient(queries, mutations, fragments, subscriptions);
 }

--- a/src/GraphbackServer.ts
+++ b/src/GraphbackServer.ts
@@ -9,7 +9,7 @@ const ENDPOINT = "/graphql";
 
 export class GraphbackServer {
   private graphqlSchema: string;
-  private httpServer?: Server;
+  private httpServer: Server;
   private serverPort?: number;
 
   constructor(httpServer: Server, graphqlSchema: string) {

--- a/src/GraphbackServer.ts
+++ b/src/GraphbackServer.ts
@@ -63,11 +63,11 @@ export class GraphbackServer {
   public getSubscriptionsUrl(): string {
     if (this.serverPort === undefined) {
       throw new Error(
-        `can not retrieve the httpUrl because the server has not been started yet`
+        `can not retrieve the subscriptions url because the server has not been started yet`
       );
     }
 
-    return `http://localhost:${this.serverPort}${ENDPOINT}`;
+    return `ws://localhost:${this.serverPort}${ENDPOINT}`;
   }
 
   public getSchema(): string {

--- a/src/GraphbackServer.ts
+++ b/src/GraphbackServer.ts
@@ -1,6 +1,5 @@
 import { ApolloServer, PubSub } from "apollo-server-express";
 import newExpress from "express";
-import { Express } from "express-serve-static-core";
 import { GraphbackDataProvider, GraphQLBackendCreator } from "graphback";
 import { Server, createServer } from "http";
 import { getAvailablePort } from "./utils";

--- a/src/GraphbackServer.ts
+++ b/src/GraphbackServer.ts
@@ -2,19 +2,18 @@ import { ApolloServer, PubSub } from "apollo-server-express";
 import newExpress from "express";
 import { Express } from "express-serve-static-core";
 import { GraphbackDataProvider, GraphQLBackendCreator } from "graphback";
-import { Server } from "http";
+import { Server, createServer } from "http";
 import { getAvailablePort } from "./utils";
 
 const ENDPOINT = "/graphql";
 
 export class GraphbackServer {
-  private express: Express;
   private graphqlSchema: string;
   private httpServer?: Server;
   private serverPort?: number;
 
-  constructor(express: Express, graphqlSchema: string) {
-    this.express = express;
+  constructor(httpServer: Server, graphqlSchema: string) {
+    this.httpServer = httpServer;
     this.graphqlSchema = graphqlSchema;
   }
 
@@ -29,13 +28,13 @@ export class GraphbackServer {
       }
     }
 
-    this.httpServer = this.express.listen({ port });
+    this.httpServer.listen({ port });
     this.serverPort = port;
   }
 
   public async stop(): Promise<void> {
     const server = this.httpServer;
-    if (server === undefined) {
+    if (!server.listening) {
       return;
     }
 
@@ -52,6 +51,16 @@ export class GraphbackServer {
   }
 
   public getHttpUrl(): string {
+    if (this.serverPort === undefined) {
+      throw new Error(
+        `can not retrieve the httpUrl because the server has not been started yet`
+      );
+    }
+
+    return `http://localhost:${this.serverPort}${ENDPOINT}`;
+  }
+
+  public getSubscriptionsUrl(): string {
     if (this.serverPort === undefined) {
       throw new Error(
         `can not retrieve the httpUrl because the server has not been started yet`
@@ -81,5 +90,8 @@ export async function initGraphbackServer(
 
   apollo.applyMiddleware({ app: express, path: ENDPOINT });
 
-  return new GraphbackServer(express, runtime.schema);
+  const httpServer = createServer(express);
+  apollo.installSubscriptionHandlers(httpServer);
+
+  return new GraphbackServer(httpServer, runtime.schema);
 }

--- a/src/GraphbackServer.ts
+++ b/src/GraphbackServer.ts
@@ -59,7 +59,7 @@ export class GraphbackServer {
     return `http://localhost:${this.serverPort}${ENDPOINT}`;
   }
 
-  public getSubscriptionsUrl(): string {
+  public getWsUrl(): string {
     if (this.serverPort === undefined) {
       throw new Error(
         `can not retrieve the subscriptions url because the server has not been started yet`

--- a/src/TestxApi.ts
+++ b/src/TestxApi.ts
@@ -15,6 +15,8 @@ export interface TestxApi {
 
   httpUrl(): Promise<string>;
 
+  wsUrl(): Promise<string>;
+
   getGraphQlSchema(): Promise<string>;
 
   getDatabaseSchema(): Promise<DatabaseSchema>;
@@ -44,6 +46,9 @@ class FakeApi implements TestxApi {
     throw new Error("fake");
   }
   public httpUrl(): Promise<string> {
+    throw new Error("fake");
+  }
+  public wsUrl(): Promise<string> {
     throw new Error("fake");
   }
   public getGraphQlSchema(): Promise<string> {

--- a/src/TestxApi.ts
+++ b/src/TestxApi.ts
@@ -26,6 +26,8 @@ export interface TestxApi {
   getQueries(): Promise<StringDic>;
 
   getMutations(): Promise<StringDic>;
+
+  getSubscriptions(): Promise<StringDic>
 }
 
 class FakeApi implements TestxApi {
@@ -60,6 +62,9 @@ class FakeApi implements TestxApi {
     throw new Error("fake");
   }
   public getMutations(): Promise<StringDic> {
+    throw new Error("fake");
+  }
+  public getSubscriptions(): Promise<StringDic> {
     throw new Error("fake");
   }
 }

--- a/src/TestxDirector.ts
+++ b/src/TestxDirector.ts
@@ -61,4 +61,8 @@ export class TestxDirector implements TestxApi {
   public async getMutations(): Promise<{ [name: string]: string }> {
     return await this.call("getMutations");
   }
+
+  public async getSubscriptions(): Promise<{ [name: string]: string }> {
+    return await this.call("getSubscriptions");
+  }
 }

--- a/src/TestxDirector.ts
+++ b/src/TestxDirector.ts
@@ -38,6 +38,10 @@ export class TestxDirector implements TestxApi {
     return await this.call("httpUrl");
   }
 
+  public async wsUrl(): Promise<string> {
+    return await this.call("wsUrl");
+  }
+
   public async getGraphQlSchema(): Promise<string> {
     return await this.call("getGraphQlSchema");
   }

--- a/src/TestxServer.test.ts
+++ b/src/TestxServer.test.ts
@@ -33,7 +33,6 @@ test("test start() and close() methods", async t => {
 
 test.only("should start the server after closing it", async t => {
   const server = new TestxServer(ITEM_MODEL);
-
   await server.start();
   const httpUrl = await server.httpUrl()
   const mutations = await server.getMutations();

--- a/src/TestxServer.test.ts
+++ b/src/TestxServer.test.ts
@@ -31,7 +31,7 @@ test("test start() and close() methods", async t => {
   );
 });
 
-test.only("should start the server after closing it", async t => {
+test("should start the server after closing it", async t => {
   const server = new TestxServer(ITEM_MODEL);
   await server.start();
   const httpUrl = await server.httpUrl()
@@ -159,7 +159,8 @@ test("getGraphQLSchema() method should produce GQL schema with required definiti
     "ItemInput",
     "ItemFilter",
     "Query",
-    "Mutation"
+    "Mutation",
+    "Subscription"
   ];
 
   await server.start();

--- a/src/TestxServer.ts
+++ b/src/TestxServer.ts
@@ -123,7 +123,7 @@ export class TestxServer implements TestxApi {
   /**
    * Get the subscriptions URL.
    */
-  public async subscriptionsUrl(): Promise<string> {
+  public async wsUrl(): Promise<string> {
     if (this.server === undefined) {
       throw new Error(
         `can not retrieve the subscriptions url from undefined server, ` +
@@ -131,7 +131,7 @@ export class TestxServer implements TestxApi {
       );
     }
 
-    return Promise.resolve(this.server.getSubscriptionsUrl());
+    return Promise.resolve(this.server.getWsUrl());
   }
 
   /**

--- a/src/TestxServer.ts
+++ b/src/TestxServer.ts
@@ -108,6 +108,7 @@ export class TestxServer implements TestxApi {
 
   /**
    * Get the server URL.
+   * This URL is used to make basic queries and mutations.
    */
   public async httpUrl(): Promise<string> {
     if (this.server === undefined) {
@@ -122,6 +123,7 @@ export class TestxServer implements TestxApi {
 
   /**
    * Get the subscriptions URL.
+   * This URL is used to make subscription queries.
    */
   public async wsUrl(): Promise<string> {
     if (this.server === undefined) {

--- a/src/TestxServer.ts
+++ b/src/TestxServer.ts
@@ -230,7 +230,7 @@ export class TestxServer implements TestxApi {
    * Get the generated client subscriptions.
    * @return {Object} An object containing the subscriptions as properties
    */
-  public getSubscriptions(): { [name: string]: string } {
+  public async getSubscriptions(): Promise<StringDic> {
     if (this.client === undefined) {
       throw new Error(
         `can not retrieve client subscriptions from undefined client, ` +
@@ -238,6 +238,6 @@ export class TestxServer implements TestxApi {
       );
     }
 
-    return this.client.getSubscriptions();
+    return Promise.resolve(this.client.getSubscriptions());
   }
 }

--- a/src/TestxServer.ts
+++ b/src/TestxServer.ts
@@ -121,6 +121,20 @@ export class TestxServer implements TestxApi {
   }
 
   /**
+   * Get the subscriptions URL.
+   */
+  public async subscriptionsUrl(): Promise<string> {
+    if (this.server === undefined) {
+      throw new Error(
+        `can not retrieve the subscriptions url from undefined server, ` +
+          `use bootstrap() or start() in order to initialize the server`
+      );
+    }
+
+    return Promise.resolve(this.server.getSubscriptionsUrl());
+  }
+
+  /**
    * Get the generated GraphQL schema.
    * Only returns the GraphQL schema if it's called after using bootstrap() or
    * start() methods.

--- a/src/TestxServer.ts
+++ b/src/TestxServer.ts
@@ -15,9 +15,9 @@ const DEFAULT_CONFIG = {
   findAll: true,
   find: true,
   delete: true,
-  subCreate: false,
-  subUpdate: false,
-  subDelete: false,
+  subCreate: true,
+  subUpdate: true,
+  subDelete: true,
   disableGen: false
 };
 

--- a/src/TestxServer.ts
+++ b/src/TestxServer.ts
@@ -224,4 +224,20 @@ export class TestxServer implements TestxApi {
 
     return Promise.resolve(this.client.getMutations());
   }
+
+
+    /**
+   * Get the generated client subscriptions.
+   * @return {Object} An object containing the subscriptions as properties
+   */
+  public getSubscriptions(): { [name: string]: string } {
+    if (this.client === undefined) {
+      throw new Error(
+        `can not retrieve client subscriptions from undefined client, ` +
+          `use bootstrap() or start() in order to initialize the client`
+      );
+    }
+
+    return this.client.getSubscriptions();
+  }
 }


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.
-->

### Description

This PR adds the featuring of exposing client subscriptions to the user.
The subscriptions can be obtained by using `TestxServer.getSubscriptions()`.

**Example**:

```javascript
const server = new TestxServer(`
  type Item {
    id: ID!
    title: String!
  }`);

await server.start();

const NEW_ITEM = gql`${server.getSubscriptions().newItem}`
const UPDATED_ITEM = gql`${server.getSubscriptions().updatedItem}`
const DELETED_ITEM = gql`${server.getSubscriptions().deletedItem}`
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] `npm run build` works
- [x] tests are included
- [X] documentation is changed or added