### PR TITLE
chore: add optional port to TestxController start

### DIFF
--- a/src/TestxApi.test.ts
+++ b/src/TestxApi.test.ts
@@ -1,8 +1,10 @@
 import test from "ava";
 import { isTestxApiMethod } from "./TestxApi";
+import { TestxServer } from "./TestxServer";
 
 test("is TestxApi method", t => {
-  t.true(isTestxApiMethod("setData"));
-  t.true(isTestxApiMethod("start"));
-  t.false(isTestxApiMethod("foo"));
+  const testx = new TestxServer(``);
+  t.true(isTestxApiMethod(testx, "setData"));
+  t.true(isTestxApiMethod(testx, "start"));
+  t.false(isTestxApiMethod(testx, "foo"));
 });

--- a/src/TestxApi.ts
+++ b/src/TestxApi.ts
@@ -28,42 +28,9 @@ export interface TestxApi {
   getMutations(): Promise<StringDic>;
 }
 
-class FakeApi implements TestxApi {
-  public start(): Promise<void> {
-    throw new Error("fake");
-  }
-  public stop(): Promise<void> {
-    throw new Error("fake");
-  }
-  public close(): Promise<void> {
-    throw new Error("fake");
-  }
-  public cleanDatabase(): Promise<void> {
-    throw new Error("fake");
-  }
-  public httpUrl(): Promise<string> {
-    throw new Error("fake");
-  }
-  public getGraphQlSchema(): Promise<string> {
-    throw new Error("fake");
-  }
-  public getDatabaseSchema(): Promise<DatabaseSchema> {
-    throw new Error("fake");
-  }
-  public setData(): Promise<void> {
-    throw new Error("fake");
-  }
-  public bootstrap(): Promise<void> {
-    throw new Error("fake");
-  }
-  public getQueries(): Promise<StringDic> {
-    throw new Error("fake");
-  }
-  public getMutations(): Promise<StringDic> {
-    throw new Error("fake");
-  }
-}
-
-export function isTestxApiMethod(name: string): name is keyof TestxApi {
-  return name in new FakeApi();
+export function isTestxApiMethod(
+  testx: TestxApi,
+  name: string
+): name is keyof TestxApi {
+  return name in testx;
 }

--- a/src/TestxController.test.ts
+++ b/src/TestxController.test.ts
@@ -1,0 +1,56 @@
+import test, { ExecutionContext } from "ava";
+import { TestxServer } from "./TestxServer";
+import { TestxController } from "./TestxController";
+import axios from "axios";
+
+function newTestxController(): TestxController {
+  const server = new TestxServer(``);
+  return new TestxController(server);
+}
+
+async function isNotConnectionRefused(
+  t: ExecutionContext,
+  url: string
+): Promise<void> {
+  try {
+    await axios(url);
+  } catch (e) {
+    t.assert(e.code !== "ECONNREFUSED");
+  }
+}
+
+test("start TestxController to a random port", async t => {
+  t.plan(1);
+
+  const controller = newTestxController();
+  await controller.start();
+  const url = await controller.httpUrl();
+
+  await isNotConnectionRefused(t, url);
+
+  await controller.close();
+});
+
+test("start TestxController to a specific port", async t => {
+  t.plan(1);
+
+  const controller = newTestxController();
+  await controller.start(7896);
+  await isNotConnectionRefused(t, "http://localhost:7896");
+
+  await controller.close();
+});
+
+test("start TestxController multiple times", async t => {
+  const controller = newTestxController();
+  await controller.start();
+  const urlV1 = await controller.httpUrl();
+
+  await t.notThrowsAsync(
+    async () => await controller.start(),
+    "should not throw an error"
+  );
+
+  const urlV2 = await controller.httpUrl();
+  t.assert(urlV1 === urlV2, "the url should not change");
+});


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.
-->

### Description

When starting the TestxDirector it should be possible to define a fixed port.

Plus I've also removed the `FakeTestx` class

<!-- Please provide a description of your pull request and any relevant steps needed to verify it.
If it fixes a bug or resolves a feature request, be sure to link to that issue.-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] `npm run build` works
- [x] tests are included