### PR TITLE
Add serviceBuilder option to overwrite the default GraphbackCRUDService

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,7 +18,10 @@
         "plugin:@typescript-eslint/recommended-requiring-type-checking",
         "prettier",
         "prettier/@typescript-eslint"
-      ]
+      ],
+      "rules": {
+        "@typescript-eslint/prefer-readonly": "warn"
+      }
     },
     {
       "files": "**/*.js",

--- a/examples/offix/test/offline.test.ts
+++ b/examples/offix/test/offline.test.ts
@@ -14,7 +14,7 @@ import { TestxServer } from "../../../dist/src";
 
 class ToggleableNetworkStatus implements NetworkStatus {
   private online = true;
-  private callbacks: NetworkStatusChangeCallback[] = [];
+  private readonly callbacks: NetworkStatusChangeCallback[] = [];
 
   public onStatusChangeListener(callback: NetworkStatusChangeCallback): void {
     this.callbacks.push(callback);

--- a/src/GraphbackClient.ts
+++ b/src/GraphbackClient.ts
@@ -1,9 +1,4 @@
-import {
-  GraphbackCRUDGeneratorConfig,
-  createClient,
-  graphQLInputContext,
-  ClientDocument
-} from "graphback";
+import { createClient, ClientDocument, InputModelTypeContext } from "graphback";
 
 interface StringDic {
   [key: string]: string;
@@ -25,10 +20,10 @@ function insertImplInto(
 }
 
 export class GraphbackClient {
-  private queries: StringDic;
-  private mutations: StringDic;
-  private fragments: StringDic;
-  private subscriptions: StringDic;
+  private readonly queries: StringDic;
+  private readonly mutations: StringDic;
+  private readonly fragments: StringDic;
+  private readonly subscriptions: StringDic;
 
   constructor(
     queries: StringDic,
@@ -60,27 +55,30 @@ export class GraphbackClient {
 }
 
 export async function initGraphbackClient(
-  schemaText: string,
-  config: GraphbackCRUDGeneratorConfig
+  context: InputModelTypeContext[]
 ): Promise<GraphbackClient> {
   const fragments: StringDic = {};
   const queries: StringDic = {};
   const mutations: StringDic = {};
   const subscriptions: StringDic = {};
 
-  const inputContext = graphQLInputContext.createModelContext(
-    schemaText,
-    config
-  );
-  const client = await createClient(inputContext, { output: "gql" });
+  const client = await createClient(context, { output: "gql" });
 
-  if (client.fragments !== undefined)
+  if (client.fragments !== undefined) {
     insertImplInto(client.fragments, fragments);
-  if (client.queries !== undefined) insertImplInto(client.queries, queries);
-  if (client.mutations !== undefined)
+  }
+
+  if (client.queries !== undefined) {
+    insertImplInto(client.queries, queries);
+  }
+
+  if (client.mutations !== undefined) {
     insertImplInto(client.mutations, mutations);
-  if (client.subscriptions !== undefined)
+  }
+
+  if (client.subscriptions !== undefined) {
     insertImplInto(client.subscriptions, subscriptions);
+  }
 
   return new GraphbackClient(queries, mutations, fragments, subscriptions);
 }

--- a/src/InMemoryDatabase.ts
+++ b/src/InMemoryDatabase.ts
@@ -5,8 +5,8 @@ import knexCleaner from "knex-cleaner";
 import { DatabaseSchema, ImportData } from "./TestxApi";
 
 export class InMemoryDatabase {
-  private knex: Knex;
-  private provider: KnexDBDataProvider;
+  private readonly knex: Knex;
+  private readonly provider: KnexDBDataProvider;
 
   constructor(knex: Knex) {
     this.knex = knex;

--- a/src/TestxController.ts
+++ b/src/TestxController.ts
@@ -9,8 +9,8 @@ import { Express } from "express-serve-static-core";
 type UnknownFunction = (...args: unknown[]) => unknown;
 
 export class TestxController {
-  private testxServer: TestxServer;
-  private expressApp: Express;
+  private readonly testxServer: TestxServer;
+  private readonly expressApp: Express;
   private controllerServer?: Server;
   private controllerPort?: number;
 

--- a/src/TestxDirector.ts
+++ b/src/TestxDirector.ts
@@ -2,7 +2,7 @@ import axios from "axios";
 import { TestxApi, DatabaseSchema, ImportData } from "./TestxApi";
 
 export class TestxDirector implements TestxApi {
-  private endpoint: string;
+  private readonly endpoint: string;
 
   constructor(url: string) {
     this.endpoint = url;

--- a/src/TestxServer.ts
+++ b/src/TestxServer.ts
@@ -221,10 +221,7 @@ export class TestxServer implements TestxApi {
     }
 
     if (this.client === undefined) {
-      this.client = await initGraphbackClient(
-        this.options.schema,
-        DEFAULT_CONFIG
-      );
+      this.client = await initGraphbackClient(this.context);
     }
   }
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.
-->

### Description

See the test for how it works: https://github.com/aerogear/graphql-testx/blob/cdd389e7464354740bb5f150e2284919155538c6/src/TestxServer.test.ts#L199

I've opened a follow-up issue to document this feature #112 , because I would like to first test the feature and agree on the interface.

Resolves: #100 

<!-- Please provide a description of your pull request and any relevant steps needed to verify it.
If it fixes a bug or resolves a feature request, be sure to link to that issue.-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] `npm run build` works
- [x] tests are included
- [ ] documentation is changed or added
