### PR TITLE
fix: expose testx fields

### DIFF
--- a/src/TestxServer.ts
+++ b/src/TestxServer.ts
@@ -49,11 +49,11 @@ export interface TestxServerOptions {
  * await server.close();
  */
 export class TestxServer implements TestxApi {
-  private readonly options: TestxServerOptions;
-  private readonly context: InputModelTypeContext[];
-  private client?: GraphbackClient;
-  private server?: GraphbackServer;
-  private database?: InMemoryDatabase;
+  protected readonly options: TestxServerOptions;
+  protected readonly context: InputModelTypeContext[];
+  protected client?: GraphbackClient;
+  protected server?: GraphbackServer;
+  protected database?: InMemoryDatabase;
 
   /**
    * Create a TestxServer.


### PR DESCRIPTION

![Screenshot 2019-12-11 at 16 28 26](https://user-images.githubusercontent.com/981838/70640078-4da83300-1c33-11ea-8a41-37cf2353eecf.png)
To extend server - for example define different migration rules etc. we need to have the ability to get access to internal fields.