### PR TITLE
Short the TestxDirector import syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,7 +368,7 @@ Client API for the `TestxController` that implements all `TestxServer` methods.
 Is used in combination wit the `TestxController`.
 
 ```ts
-import { TestxDirector } from "graphql-testx/dist/src/TestxDirector";
+import { TestxDirector } from "graphql-testx/director";
 
 // controller: TestxController
 // controllerHttpUrl = await controller.httpUrl();

--- a/director.js
+++ b/director.js
@@ -1,0 +1,4 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var TestxDirector_1 = require("./dist/src/TestxDirector");
+exports.TestxDirector = TestxDirector_1.TestxDirector;

--- a/examples/karma/test/mutations.test.js
+++ b/examples/karma/test/mutations.test.js
@@ -1,5 +1,5 @@
 /* global __karma__ */
-const { TestxDirector } = require("../../../dist/src/TestxDirector");
+const { TestxDirector } = require("../../../");
 const { request } = require("graphql-request");
 const { expect } = require("chai");
 

--- a/examples/karma/test/mutations.test.js
+++ b/examples/karma/test/mutations.test.js
@@ -1,5 +1,5 @@
 /* global __karma__ */
-const { TestxDirector } = require("../../../");
+const { TestxDirector } = require("../../../director");
 const { request } = require("graphql-request");
 const { expect } = require("chai");
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export { TestxServer } from "./TestxServer";
 export { TestxController } from "./TestxController";
+export { TestxDirector } from "./TestxDirector";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,2 @@
 export { TestxServer } from "./TestxServer";
 export { TestxController } from "./TestxController";
-export { TestxDirector } from "./TestxDirector";


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.
-->

### Description

I did some experiments and with this changes, it will be possible to import the TestxDirector in this way:
```js
const { TestxDirector } from "graphql-testx/director"
```

Resolves: #118 

<!-- Please provide a description of your pull request and any relevant steps needed to verify it.
If it fixes a bug or resolves a feature request, be sure to link to that issue.-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] `npm run build` works
- [x] tests are included
- [x] documentation is changed or added
