### PR TITLE
fix: Use gqlwithfragment

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "typescript": "3.7.3"
   },
   "dependencies": {
-    "@graphback/codegen-client": "^0.10.0-dev6",
+    "@graphback/codegen-client": "0.10.0-dev6",
     "apollo-server-express": "2.9.13",
     "axios": "0.19.0",
     "express": "4.17.1",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "typescript": "3.7.3"
   },
   "dependencies": {
+    "@graphback/codegen-client": "^0.10.0-dev6",
     "apollo-server-express": "2.9.13",
     "axios": "0.19.0",
     "express": "4.17.1",

--- a/src/GraphbackClient.ts
+++ b/src/GraphbackClient.ts
@@ -1,5 +1,5 @@
-import { createClient, ClientDocument, InputModelTypeContext } from "graphback";
-
+import { createClient, ClientDocument } from "@graphback/codegen-client";
+import { InputModelTypeContext } from "graphback";
 interface StringDic {
   [key: string]: string;
 }
@@ -62,7 +62,7 @@ export async function initGraphbackClient(
   const mutations: StringDic = {};
   const subscriptions: StringDic = {};
 
-  const client = await createClient(context, { output: "gql" });
+  const client = await createClient(context, { output: "gqlwithfragment" });
 
   if (client.fragments !== undefined) {
     insertImplInto(client.fragments, fragments);


### PR DESCRIPTION
Latest version of graphback stopped including fragments. 
To not produce hasle on testx users I have brought new type to generate fully featured queries